### PR TITLE
msgs: deal with CMake CMP0094

### DIFF
--- a/boeing_gazebo_model_attachment_plugin_msgs/CMakeLists.txt
+++ b/boeing_gazebo_model_attachment_plugin_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(boeing_gazebo_model_attachment_plugin_msgs)
 
 # Default to C++17


### PR DESCRIPTION
As per subject.

Bump CMake minimum version to `3.15`, as that's where `CMP0094` was introduced.

CMake versions lower than `3.15` have trouble locating Python in environments where a Python installed in a non-default location should be used (such as Conda, Pixi, etc).

This should still be compatible with ROS 2 distributions such as Humble, which require CMake `3.22` (at least on Ubuntu).